### PR TITLE
récupérer inputs par leur name

### DIFF
--- a/src/reform/FormManager.ts
+++ b/src/reform/FormManager.ts
@@ -319,7 +319,7 @@ export class FormManager<T extends object> {
                 else {
                     console.error("Validation errors", _this.errors.values())
                     const firstErrorKey = _this.errors.paths()?.[0]
-                    const element = window.document.getElementById(firstErrorKey)
+                    const element = window.document.querySelector(`[name="${firstErrorKey}"]`) as HTMLElement | null
                     if (element) {
                         setTimeout(() => {
                             element.focus()


### PR DESCRIPTION
Salut @fwolff , 

Je voudrais utiliser le hook `useId` pour générer des identifiants uniques pour les champs dans le design system, c'est pratique pour moi.

Mais cela veut dire que pour scroller jusqu'à un champ, il faut se baser sur son name et pas son id (qui n'est plus lié au nom sémantique du champ). 

Qu'en penses-tu ? 

On peut aussi imaginer cibler les deux cas : 
```
window.document.querySelector(`#${firstErrorKey}, [name="${firstErrorKey}"]`)
```